### PR TITLE
fix decoding of 7bit messages.  Decode all IEIs in a user data header.

### DIFF
--- a/lib/pdu_tools/encoder.rb
+++ b/lib/pdu_tools/encoder.rb
@@ -102,7 +102,11 @@ module PDUTools
     def prepare_recipient recipient
       Phoner::Phone.default_country_code ||= "421"
       address_type = "91" # International
-      address = Phoner::Phone.parse(recipient).format("%c%a%n")
+      if @options[:force_recipient]
+        address = recipient
+      else
+        address = Phoner::Phone.parse(recipient).format("%c%a%n")
+      end
       address_length = "%02X" % address.length
       address_encoded = normal2swapped address
       address_length + address_type + address_encoded

--- a/lib/pdu_tools/helpers.rb
+++ b/lib/pdu_tools/helpers.rb
@@ -73,7 +73,7 @@ module PDUTools
       string.scan(/../).collect(&:reverse).join.gsub(/F$/,'')
     end
 
-    def decode7bit textdata, offset=1
+    def decode7bit textdata, length = nil, offset = 1
       ret = ""
       bytes = []
       textdata.split('').each_slice(2) do |s|
@@ -100,7 +100,11 @@ module PDUTools
         end
         next_septet = nil
       end
-      ret
+      if length
+        ret[0..length - 1]
+      else
+        ret
+      end
     end
 
     def decode8bit data, length

--- a/lib/pdu_tools/message_part.rb
+++ b/lib/pdu_tools/message_part.rb
@@ -14,7 +14,8 @@ module PDUTools
 
     def complete?
       return true unless @user_data_header
-      if @user_data_header[:parts] > 1
+      return true unless @user_data_header[:multipart]
+      if @user_data_header[:multipart][:parts] > 1
         false
       else
         true

--- a/spec/decoder_spec.rb
+++ b/spec/decoder_spec.rb
@@ -28,8 +28,9 @@ describe PDUTools::Decoder do
     it "should decode" do
       message_part = decoder.decode
       expect(message_part.user_data_header).to be_present
-      expect(message_part.user_data_header[:parts]).to eq 2
-      expect(message_part.user_data_header[:part_number]).to eq 1
+      expect(message_part.user_data_header[:multipart]).to be_present
+      expect(message_part.user_data_header[:multipart][:parts]).to eq 2
+      expect(message_part.user_data_header[:multipart][:part_number]).to eq 1
     end
   end
 

--- a/spec/encoder_spec.rb
+++ b/spec/encoder_spec.rb
@@ -2,41 +2,56 @@
 require 'spec_helper'
 
 describe PDUTools::Encoder do
-  let(:recipient) { "+421 900 100 100" }
-  let(:encoder) { PDUTools::Encoder.new recipient: recipient, message: message }
-  context "short" do
-    context "7bit text" do
-      let(:message) { "This is a test message" }
-      it "should encode pdu" do
-        pdus = encoder.encode
-        expect(pdus.size).to eq(1)
+  context "encoding" do
+    let(:recipient) { "+421 900 100 100" }
+    let(:encoder) { PDUTools::Encoder.new recipient: recipient, message: message }
+    context "short" do
+      context "7bit text" do
+        let(:message) { "This is a test message" }
+        it "should encode pdu" do
+          pdus = encoder.encode
+          expect(pdus.size).to eq(1)
+        end
+      end
+
+      context "16bit text" do
+        let(:message) { "This is diacritics ľščťžýáíäúôň" }
+        it "should encode pdu" do
+          pdus = encoder.encode
+          expect(pdus.size).to eq(1)
+        end
       end
     end
 
-    context "16bit text" do
-      let(:message) { "This is diacritics ľščťžýáíäúôň" }
-      it "should encode pdu" do
-        pdus = encoder.encode
-        expect(pdus.size).to eq(1)
+    context "lonh" do
+      context "7bit text" do
+        let(:message) { "This is a test message" * 10 }
+        it "should encode pdu" do
+          pdus = encoder.encode
+          expect(pdus.size).to eq(2)
+        end
+      end
+
+      context "16bit text" do
+        let(:message) { "This is diacritics ľščťžýáíäúôň" * 3 }
+        it "should encode pdu" do
+          pdus = encoder.encode
+          expect(pdus.size).to eq(2)
+        end
       end
     end
   end
 
-  context "lonh" do
-    context "7bit text" do
-      let(:message) { "This is a test message" * 10 }
-      it "should encode pdu" do
-        pdus = encoder.encode
-        expect(pdus.size).to eq(2)
-      end
+  context "recipient" do
+    it "should fail on 71730 without force" do
+      expect { PDUTools::Encoder.new recipient: "71730", message: "test" }.to raise_error(Phoner::AreaCodeError)
     end
 
-    context "16bit text" do
-      let(:message) { "This is diacritics ľščťžýáíäúôň" * 3 }
-      it "should encode pdu" do
-        pdus = encoder.encode
-        expect(pdus.size).to eq(2)
-      end
+    it "should succeed on 71730 with force" do
+      encoder = PDUTools::Encoder.new recipient: "71730", force_recipient: true, message: "test"
+      pdus = encoder.encode
+      expect(pdus.size).to eq(1)
     end
+
   end
 end


### PR DESCRIPTION
This patch implements the changes described in the two tickets I opened tonight.  It does change the API a bit if people reach directly into the user_data_header return value, but the advantage is we can now decode any user data header IEI, and later skip (rather than throw) on unknown ones, possibly including them for the user to decode.
